### PR TITLE
added support for proxy in environment variables

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -19,7 +19,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/ararog/timeago"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -29,6 +28,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ararog/timeago"
 )
 
 var (
@@ -240,6 +241,7 @@ func HttpRequest(url, method string, content interface{}, headers []string, body
 		DisableKeepAlives:     true,
 		ResponseHeaderTimeout: timeout,
 		TLSHandshakeTimeout:   timeout,
+		Proxy:                 http.ProxyFromEnvironment,
 	}
 	client := &http.Client{
 		Transport: transport,


### PR DESCRIPTION
In some environments exist corporate proxies, this pull request add support for environment variables in statping binary, like this reference explains:  [https://golang.org/pkg/net/http/#ProxyFromEnvironment](https://golang.org/pkg/net/http/#ProxyFromEnvironment). The prupose is monitor internal and external services/apis that need proxy configurations