### PR TITLE
Set Postgres SSL Mode to env POSTGRES_SSLMODE value

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -227,6 +227,7 @@ func HelpEcho() {
 	fmt.Println("     DB_PORT                   - Database port (5432, 3306, ...)")
 	fmt.Println("     DB_DATABASE               - Database connection's database name")
 	fmt.Println("     POSTGRES_SSL              - Enable Postgres SSL Mode 'ssl_mode=enabled' (true/false)")
+	fmt.Println("     POSTGRES_SSLMODE          - Set Postgres SSL Mode to supplied value")
 	fmt.Println("     GO_ENV                    - Run Statping in testmode, will bypass HTTP authentication (if set as 'true')")
 	fmt.Println("     NAME                      - Set a name for the Statping status page")
 	fmt.Println("     DESCRIPTION               - Set a description for the Statping status page")

--- a/core/database.go
+++ b/core/database.go
@@ -180,6 +180,7 @@ func (db *DbConfig) InsertCore() (*Core, error) {
 // Connect will attempt to connect to the sqlite, postgres, or mysql database
 func (db *DbConfig) Connect(retry bool, location string) error {
 	postgresSSL, _ := strconv.ParseBool(os.Getenv("POSTGRES_SSL"))
+	postgresSSLMode := os.Getenv("POSTGRES_SSLMODE")
 	if DbSession != nil {
 		return nil
 	}
@@ -201,6 +202,11 @@ func (db *DbConfig) Connect(retry bool, location string) error {
 		if postgresSSL {
 			sslMode = "enabled"
 		}
+
+		if postgresSSLMode != "" {
+			sslMode = postgresSSLMode
+		}
+
 		conn = fmt.Sprintf("host=%v port=%v user=%v dbname=%v password=%v timezone=UTC sslmode=%v", Configs.DbHost, Configs.DbPort, Configs.DbUser, Configs.DbData, Configs.DbPass, sslMode)
 	case "mssql":
 		host := fmt.Sprintf("%v:%v", Configs.DbHost, Configs.DbPort)


### PR DESCRIPTION
PostgreSQL 11.1 on my machine supports sslmode set to only one of the following values: "require" (default), "verify-full", "verify-ca", and "disable" ([docs](https://www.postgresql.org/docs/11/libpq-ssl.html))

Setting env var POSTGRES_SSL=false results in the following error in statping logs:
`FATAL: pq: unsupported sslmode "disabled"; only "require" (default), "verify-full", "verify-ca", and "disable" supported`

I suggest we allow setting the `sslmode` to a user supplied value set using the `POSTGRES_SSLMODE` env var.

Fixes:
#75
#128

Sample `docker-compose.yml` that uses an image with this PR:

```
version: '2.3'

services:
  statping:
    container_name: statping
    image: dotslashlabs/statping:latest
    restart: always
    ports:
      - 0.0.0.0:8080:8080
    networks:
      - database
    depends_on:
      - statping_postgres
    volumes:
      - ./statping/app:/app
    environment:
      VIRTUAL_HOST: localhost
      VIRTUAL_PORT: 8080
      DB_CONN: postgres
      DB_HOST: statping_postgres
      DB_PORT: 5432
      DB_USER: statping
      DB_PASS: password1234
      DB_DATABASE: statping
      # POSTGRES_SSL: 'false' # uncomment this and comment next line to see issue
      POSTGRES_SSLMODE: disable
      NAME: EC2 Example
      DESCRIPTION: This is a Statping Docker Compose instance

  statping_postgres:
    container_name: statping_postgres
    image: postgres:11.1-alpine
    restart: always
    networks:
      - database
    volumes:
      - ./statping/postgres:/var/lib/postgresql/data
    environment:
      POSTGRES_PASSWORD: password1234
      POSTGRES_USER: statping
      POSTGRES_DB: statping

networks:
  database:
    driver: bridge
```