### PR TITLE
Fix/sni from header in tls handshake

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -241,7 +241,7 @@ func HelpEcho() {
 func checkGithubUpdates() (githubResponse, error) {
 	var gitResp githubResponse
 	url := "https://api.github.com/repos/hunterlong/statping/releases/latest"
-	contents, _, err := utils.HttpRequest(url, "GET", nil, nil, nil, time.Duration(10*time.Second))
+	contents, _, err := utils.HttpRequest(url, "GET", nil, nil, nil, time.Duration(10*time.Second), true)
 	if err != nil {
 		return githubResponse{}, err
 	}

--- a/core/checker.go
+++ b/core/checker.go
@@ -211,9 +211,9 @@ func (s *Service) checkHttp(record bool) *Service {
 	}
 
 	if s.Method == "POST" {
-		content, res, err = utils.HttpRequest(s.Domain, s.Method, "application/json", headers, bytes.NewBuffer([]byte(s.PostData.String)), timeout)
+		content, res, err = utils.HttpRequest(s.Domain, s.Method, "application/json", headers, bytes.NewBuffer([]byte(s.PostData.String)), timeout, s.VerifySSL.Bool)
 	} else {
-		content, res, err = utils.HttpRequest(s.Domain, s.Method, nil, headers, nil, timeout)
+		content, res, err = utils.HttpRequest(s.Domain, s.Method, nil, headers, nil, timeout, s.VerifySSL.Bool)
 	}
 	if err != nil {
 		if record {

--- a/notifiers/discord.go
+++ b/notifiers/discord.go
@@ -59,7 +59,7 @@ func init() {
 // Send will send a HTTP Post to the discord API. It accepts type: []byte
 func (u *discord) Send(msg interface{}) error {
 	message := msg.(string)
-	_, _, err := utils.HttpRequest(discorder.GetValue("host"), "POST", "application/json", nil, strings.NewReader(message), time.Duration(10*time.Second))
+	_, _, err := utils.HttpRequest(discorder.GetValue("host"), "POST", "application/json", nil, strings.NewReader(message), time.Duration(10*time.Second), true)
 	return err
 }
 
@@ -93,7 +93,7 @@ func (u *discord) OnSave() error {
 func (u *discord) OnTest() error {
 	outError := errors.New("Incorrect discord URL, please confirm URL is correct")
 	message := `{"content": "Testing the discord notifier"}`
-	contents, _, err := utils.HttpRequest(discorder.Host, "POST", "application/json", nil, bytes.NewBuffer([]byte(message)), time.Duration(10*time.Second))
+	contents, _, err := utils.HttpRequest(discorder.Host, "POST", "application/json", nil, bytes.NewBuffer([]byte(message)), time.Duration(10*time.Second), true)
 	if string(contents) == "" {
 		return nil
 	}

--- a/notifiers/line_notify.go
+++ b/notifiers/line_notify.go
@@ -62,7 +62,7 @@ func (u *lineNotifier) Send(msg interface{}) error {
 	v := url.Values{}
 	v.Set("message", message)
 	headers := []string{fmt.Sprintf("Authorization=Bearer %v", u.ApiSecret)}
-	_, _, err := utils.HttpRequest("https://notify-api.line.me/api/notify", "POST", "application/x-www-form-urlencoded", headers, strings.NewReader(v.Encode()), time.Duration(10*time.Second))
+	_, _, err := utils.HttpRequest("https://notify-api.line.me/api/notify", "POST", "application/x-www-form-urlencoded", headers, strings.NewReader(v.Encode()), time.Duration(10*time.Second), true)
 	return err
 }
 

--- a/notifiers/mobile.go
+++ b/notifiers/mobile.go
@@ -176,7 +176,7 @@ func pushRequest(msg *pushArray) ([]byte, error) {
 		return nil, err
 	}
 	url := "https://push.statping.com/api/push"
-	body, _, err = utils.HttpRequest(url, "POST", "application/json", nil, bytes.NewBuffer(body), time.Duration(20*time.Second))
+	body, _, err = utils.HttpRequest(url, "POST", "application/json", nil, bytes.NewBuffer(body), time.Duration(20*time.Second), true)
 	return body, err
 }
 

--- a/notifiers/slack.go
+++ b/notifiers/slack.go
@@ -79,12 +79,13 @@ type slackMessage struct {
 	Service  *types.Service
 	Template string
 	Time     int64
+	Issue    string
 }
 
 // Send will send a HTTP Post to the slack webhooker API. It accepts type: string
 func (u *slack) Send(msg interface{}) error {
 	message := msg.(string)
-	_, _, err := utils.HttpRequest(u.Host, "POST", "application/json", nil, strings.NewReader(message), time.Duration(10*time.Second))
+	_, _, err := utils.HttpRequest(u.Host, "POST", "application/json", nil, strings.NewReader(message), time.Duration(10*time.Second), true)
 	return err
 }
 
@@ -93,7 +94,7 @@ func (u *slack) Select() *notifier.Notification {
 }
 
 func (u *slack) OnTest() error {
-	contents, _, err := utils.HttpRequest(u.Host, "POST", "application/json", nil, bytes.NewBuffer([]byte(`{"text":"testing message"}`)), time.Duration(10*time.Second))
+	contents, _, err := utils.HttpRequest(u.Host, "POST", "application/json", nil, bytes.NewBuffer([]byte(`{"text":"testing message"}`)), time.Duration(10*time.Second), true)
 	if string(contents) != "ok" {
 		return errors.New("The slack response was incorrect, check the URL")
 	}

--- a/notifiers/slack.go
+++ b/notifiers/slack.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	slackMethod     = "slack"
-	failingTemplate = `{ "attachments": [ { "fallback": "Service {{.Service.Name}} - is currently failing", "text": "Your Statping service <{{.Service.Domain}}|{{.Service.Name}}> has just received a Failure notification based on your expected results. {{.Service.Name}} responded with a HTTP Status code of {{.Service.LastStatusCode}}.", "fields": [ { "title": "Expected Status Code", "value": "{{.Service.ExpectedStatus}}", "short": true }, { "title": "Received Status Code", "value": "{{.Service.LastStatusCode}}", "short": true } ], "color": "#FF0000", "thumb_url": "https://statping.com", "footer": "Statping", "footer_icon": "https://img.cjx.io/statuplogo32.png" } ] }`
+	failingTemplate = `{ "attachments": [ { "fallback": "Service {{.Service.Name}} - is currently failing", "text": "Your Statping service <{{.Service.Domain}}|{{.Service.Name}}> has just received a Failure notification based on your expected results. {{.Service.Name}} responded with a HTTP Status code of {{.Service.LastStatusCode}}.", "fields": [ { "title": "Expected Status Code", "value": "{{.Service.ExpectedStatus}}", "short": true }, { "title": "Received Status Code", "value": "{{.Service.LastStatusCode}}", "short": true } ,{ "title": "Error Message", "value": "{{.Issue}}", "short": false } ], "color": "#FF0000", "thumb_url": "https://statping.com", "footer": "Statping", "footer_icon": "https://img.cjx.io/statuplogo32.png" } ] }`
 	successTemplate = `{ "attachments": [ { "fallback": "Service {{.Service.Name}} - is now back online", "text": "Your Statping service <{{.Service.Domain}}|{{.Service.Name}}> is now back online and meets your expected responses.", "color": "#00FF00", "thumb_url": "https://statping.com", "footer": "Statping", "footer_icon": "https://img.cjx.io/statuplogo32.png" } ] }`
 	slackText       = `{"text":"{{.}}"}`
 )
@@ -107,6 +107,7 @@ func (u *slack) OnFailure(s *types.Service, f *types.Failure) {
 		Service:  s,
 		Template: failingTemplate,
 		Time:     time.Now().Unix(),
+		Issue:    f.Issue,
 	}
 	parseSlackMessage(s.Id, failingTemplate, message)
 }

--- a/notifiers/telegram.go
+++ b/notifiers/telegram.go
@@ -78,7 +78,7 @@ func (u *telegram) Send(msg interface{}) error {
 	v.Set("text", message)
 	rb := *strings.NewReader(v.Encode())
 
-	contents, _, err := utils.HttpRequest(apiEndpoint, "GET", "application/x-www-form-urlencoded", nil, &rb, time.Duration(10*time.Second))
+	contents, _, err := utils.HttpRequest(apiEndpoint, "GET", "application/x-www-form-urlencoded", nil, &rb, time.Duration(10*time.Second), true)
 
 	success, _ := telegramSuccess(contents)
 	if !success {

--- a/notifiers/twilio.go
+++ b/notifiers/twilio.go
@@ -89,7 +89,7 @@ func (u *twilio) Send(msg interface{}) error {
 	v.Set("Body", message)
 	rb := *strings.NewReader(v.Encode())
 
-	contents, _, err := utils.HttpRequest(twilioUrl, "POST", "application/x-www-form-urlencoded", nil, &rb, time.Duration(10*time.Second))
+	contents, _, err := utils.HttpRequest(twilioUrl, "POST", "application/x-www-form-urlencoded", nil, &rb, time.Duration(10*time.Second), true)
 	success, _ := twilioSuccess(contents)
 	if !success {
 		errorOut := twilioError(contents)

--- a/source/tmpl/form_service.gohtml
+++ b/source/tmpl/form_service.gohtml
@@ -109,6 +109,16 @@
         </div>
     </div>
     <div class="form-group row">
+        <label for="order" class="col-sm-4 col-form-label">Verify SSL</label>
+        <div class="col-8 mt-1">
+            <span class="switch float-left">
+                <input type="checkbox" name="verify_ssl-option" class="switch" id="switch-verify-ssl" {{if eq .Id 0}}checked{{end}}{{if .VerifySSL.Bool}}checked{{end}}>
+                <label for="switch-verify-ssl">Verify SSL Certificate for this service</label>
+                <input type="hidden" name="verify_ssl" id="switch-verify-ssl-value" value="{{if eq .Id 0}}true{{else}}{{if .VerifySSL.Bool}}true{{else}}false{{end}}{{end}}">
+            </span>
+        </div>
+    </div>
+    <div class="form-group row">
         <label for="order" class="col-sm-4 col-form-label">Notifications</label>
         <div class="col-8 mt-1">
             <span class="switch float-left">

--- a/types/service.go
+++ b/types/service.go
@@ -34,6 +34,7 @@ type Service struct {
 	Timeout            int                `gorm:"default:30;column:timeout" json:"timeout"`
 	Order              int                `gorm:"default:0;column:order_id" json:"order_id"`
 	AllowNotifications NullBool           `gorm:"default:true;column:allow_notifications" json:"allow_notifications"`
+	VerifySSL          NullBool           `gorm:"default:false;column:verify_ssl" json:"verify_ssl"`
 	Public             NullBool           `gorm:"default:true;column:public" json:"public"`
 	GroupId            int                `gorm:"default:0;column:group_id" json:"group_id"`
 	Headers            NullString         `gorm:"column:headers" json:"headers"`

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -274,21 +274,8 @@ func SaveFile(filename string, data []byte) error {
 // // body - The body or form data to send with HTTP request
 // // timeout - Specific duration to timeout on. time.Duration(30 * time.Seconds)
 // // You can use a HTTP Proxy if you HTTP_PROXY environment variable
-func HttpRequest(url, method string, content interface{}, headers []string, body io.Reader, timeout time.Duration) ([]byte, *http.Response, error) {
+func HttpRequest(url, method string, content interface{}, headers []string, body io.Reader, timeout time.Duration, verifySSL bool) ([]byte, *http.Response, error) {
 	var err error
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
-		DisableKeepAlives:     true,
-		ResponseHeaderTimeout: timeout,
-		TLSHandshakeTimeout:   timeout,
-		Proxy:                 http.ProxyFromEnvironment,
-	}
-	client := &http.Client{
-		Transport: transport,
-		Timeout:   timeout,
-	}
 	var req *http.Request
 	if req, err = http.NewRequest(method, url, body); err != nil {
 		return nil, nil, err
@@ -310,6 +297,22 @@ func HttpRequest(url, method string, content interface{}, headers []string, body
 		}
 	}
 	var resp *http.Response
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: !verifySSL,
+			ServerName:         req.Host,
+		},
+		DisableKeepAlives:     true,
+		ResponseHeaderTimeout: timeout,
+		TLSHandshakeTimeout:   timeout,
+		Proxy:                 http.ProxyFromEnvironment,
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   timeout,
+	}
+
 	if resp, err = client.Do(req); err != nil {
 		return nil, resp, err
 	}


### PR DESCRIPTION
This pull request includes 2 related changes.
1 - 
golang http client fails handshaking when you set a custom header since it gets sni from url 
see: https://github.com/golang/go/issues/22704 
And some services needs to verify SSL because we want to make sure their certs are valid. Added SSL verification to service conf and made it optional.

![SSL Verify Option](https://i.ibb.co/2tYnDCK/Screen-Shot-2019-09-17-at-13-26-58.png)

2- 
Attached error message to slack to be able to know the root error message, not only status codes.
![Slack message](https://i.ibb.co/nbSQr1F/Screen-Shot-2019-09-17-at-13-14-42.png)

