### PR TITLE
add verifyssl field to csv import handler.

### DIFF
--- a/handlers/settings.go
+++ b/handlers/settings.go
@@ -144,7 +144,7 @@ func bulkImportHandler(w http.ResponseWriter, r *http.Request) {
 // commaToService will convert a CSV comma delimited string slice to a Service type
 // this function is used for the bulk import services feature
 func commaToService(s []string) (*types.Service, error) {
-	if len(s) != 16 {
+	if len(s) != 17 {
 		err := fmt.Errorf("does not have the expected amount of %v columns for a service", 16)
 		return nil, err
 	}
@@ -169,6 +169,11 @@ func commaToService(s []string) (*types.Service, error) {
 		return nil, err
 	}
 
+	verifySsl, err := strconv.ParseBool(s[16])
+	if err != nil {
+		return nil, err
+	}
+
 	newService := &types.Service{
 		Name:               s[0],
 		Domain:             s[1],
@@ -185,6 +190,7 @@ func commaToService(s []string) (*types.Service, error) {
 		GroupId:            int(utils.ToInt(s[13])),
 		Headers:            types.NewNullString(s[14]),
 		Permalink:          types.NewNullString(s[15]),
+		VerifySSL:          types.NewNullBool(verifySsl),
 	}
 
 	return newService, nil


### PR DESCRIPTION
So, a good reminder from this comment : https://github.com/hunterlong/statping/pull/252#issuecomment-535842365 added verifyssl to bulk_import page. It will broke importing old csv files but I think this is fine for who use csv import for defining services.