### PR TITLE
Correct Downtime Calculation

### DIFF
--- a/core/services.go
+++ b/core/services.go
@@ -260,7 +260,7 @@ func (s *Service) Downtime() time.Duration {
 	if len(hits) == 0 {
 		return time.Now().UTC().Sub(fail.CreatedAt.UTC())
 	}
-	since := fail.CreatedAt.UTC().Sub(fail.CreatedAt.UTC())
+	since := fail.CreatedAt.UTC().Sub(hits[0].CreatedAt.UTC())
 	return since
 }
 

--- a/source/tmpl/settings.gohtml
+++ b/source/tmpl/settings.gohtml
@@ -45,6 +45,7 @@
                                     <span class="switch">
                                         <input type="checkbox" name="update_notify-option" class="switch" id="switch-update_notify"{{if UPDATENOTIFY}} checked{{end}}>
                                         <label for="switch-update_notify" class="mt-2 mt-sm-0"></label>
+                                        <small class="form-text text-muted">Enabling this will send only Messages when the status of a services changes.</small>
                                     </span>
 
                                     <input type="hidden" name="update_notify" id="switch-update_notify-value" value="{{if UPDATENOTIFY}}true{{else}}false{{end}}">

--- a/types/core.go
+++ b/types/core.go
@@ -37,7 +37,7 @@ type Core struct {
 	Version       string             `gorm:"column:version" json:"version"`
 	MigrationId   int64              `gorm:"column:migration_id" json:"migration_id,omitempty"`
 	UseCdn        NullBool           `gorm:"column:use_cdn;default:false" json:"using_cdn,omitempty"`
-	UpdateNotify  NullBool           `gorm:"column:update_notify;default:false" json:"update_notify,omitempty"`
+	UpdateNotify  NullBool           `gorm:"column:update_notify;default:true" json:"update_notify,omitempty"`
 	Timezone      float32            `gorm:"column:timezone;default:-8.0" json:"timezone,omitempty"`
 	CreatedAt     time.Time          `gorm:"column:created_at" json:"created_at"`
 	UpdatedAt     time.Time          `gorm:"column:updated_at" json:"updated_at"`


### PR DESCRIPTION
Add a more detailed Textbox to the _Send Updates only_ Button so Users are not getting confused any more (Ref: #301).

And it also fixes the incorrect Downtime Calculation.


-----

Closes #301 
Fixes #306 