### PR TITLE
Disable StartTLS policy when TLS/SSL is disabled

### DIFF
--- a/notifiers/email.go
+++ b/notifiers/email.go
@@ -254,6 +254,7 @@ func (u *email) dialSend(email *emailOutgoing) error {
 	// if email setting TLS is Disabled
 	if u.ApiKey == "true" {
 		mailer.SSL = false
+		mailer.StartTLSPolicy = mail.NoStartTLS
 	} else {
 		mailer.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 	}


### PR DESCRIPTION
Disable SSL/TLS completely in the Email-Notifier if the User has disabled it.

This should fix #384.

Thanks @